### PR TITLE
Add share transcript button and improve share button labels

### DIFF
--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -893,7 +893,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
                     className="text-xs px-3 py-1.5 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1 min-w-[80px] justify-center"
                   >
                     <ShareIcon className="w-3 h-3" />
-                    <span>share transcript</span>
+                    <span>transcript</span>
                   </button>
                 )}
               </div>

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -334,6 +334,24 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
     }
   };
 
+  const handleShareTranscript = async (): Promise<void> => {
+    try {
+      const response = await fetch('/api/open-in-finder', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ filename: memo.filename, fileType: 'transcript' }),
+      });
+  
+      if (!response.ok) {
+        throw new Error('Failed to open transcript file in Finder');
+      }
+    } catch (error) {
+      console.error('Error opening transcript file in Finder:', error);
+    }
+  };
+
   const handleDeletePluginFiles = async (plugin: string): Promise<void> => {
     if (!memo.filename) return;
     
@@ -867,8 +885,17 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
                   className="text-xs px-3 py-1.5 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1 min-w-[80px] justify-center"
                 >
                   <ShareIcon className="w-3 h-3" />
-                  <span>share</span>
+                  <span>share audio</span>
                 </button>
+                {memo.transcript && (
+                  <button 
+                    onClick={handleShareTranscript}
+                    className="text-xs px-3 py-1.5 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1 min-w-[80px] justify-center"
+                  >
+                    <ShareIcon className="w-3 h-3" />
+                    <span>share transcript</span>
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -885,7 +885,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
                   className="text-xs px-3 py-1.5 rounded-md bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center gap-1 min-w-[80px] justify-center"
                 >
                   <ShareIcon className="w-3 h-3" />
-                  <span>share audio</span>
+                  <span>audio</span>
                 </button>
                 {memo.transcript && (
                   <button 


### PR DESCRIPTION
Enhanced the file sharing functionality by adding a dedicated share transcript button that opens the transcript file in Finder. The existing share button was renamed to share audio for clarity. Both buttons now have simplified labels (audio/transcript) while maintaining the share icon for visual consistency. The API was updated to support both audio and transcript file types through a new `fileType` parameter.