### PR TITLE
Add titles plugin and display titles in memo cards

### DIFF
--- a/src/app/api/memos/[filename]/route.ts
+++ b/src/app/api/memos/[filename]/route.ts
@@ -30,15 +30,17 @@ export async function GET(
     const TRANSCRIPTS_DIR = path.join(VOICE_MEMOS_DIR, 'transcripts');
     const SUMMARIES_DIR = path.join(VOICE_MEMOS_DIR, 'summaries');
     const TODOS_DIR = path.join(VOICE_MEMOS_DIR, 'TODOs');
+    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
 
     const { filename } = await params;
     const baseFilename = filename;
     
     // Get content from each plugin directory
-    const [transcript, summary, todos] = await Promise.all([
+    const [transcript, summary, todos, title] = await Promise.all([
       readFileIfExists(path.join(TRANSCRIPTS_DIR, `${baseFilename}.txt`)),
       readFileIfExists(path.join(SUMMARIES_DIR, `${baseFilename}.txt`)),
-      readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`))
+      readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`)),
+      readFileIfExists(path.join(TITLES_DIR, `${baseFilename}.txt`))
     ]);
 
     const memo = {
@@ -46,6 +48,7 @@ export async function GET(
       transcript,
       summary,
       todos,
+      title: title?.trim() || undefined,
       path: path.join(TODOS_DIR, `${baseFilename}.md`),
       createdAt: parseTimestampFromFilename(baseFilename),
       audioUrl: `/api/audio/${baseFilename}.m4a`

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -7,6 +7,7 @@ interface Memo {
   transcript?: string;
   summary?: string;
   todos?: string;
+  title?: string;
   createdAt: string;
   path: string;
   audioUrl: string;
@@ -45,6 +46,7 @@ export async function GET() {
     const TRANSCRIPTS_DIR = path.join(VOICE_MEMOS_DIR, 'transcripts');
     const SUMMARIES_DIR = path.join(VOICE_MEMOS_DIR, 'summaries');
     const TODOS_DIR = path.join(VOICE_MEMOS_DIR, 'TODOs');
+    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
 
     // Ensure default directories exist
     await Promise.all([
@@ -63,10 +65,11 @@ export async function GET() {
         const baseFilename = path.basename(audioFile, '.m4a');
         
         // Get content from each plugin directory
-        const [transcript, summary, todos] = await Promise.all([
+        const [transcript, summary, todos, title] = await Promise.all([
           readFileIfExists(path.join(TRANSCRIPTS_DIR, `${baseFilename}.txt`)),
           readFileIfExists(path.join(SUMMARIES_DIR, `${baseFilename}.txt`)),
-          readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`))
+          readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`)),
+          readFileIfExists(path.join(TITLES_DIR, `${baseFilename}.txt`))
         ]);
 
         const memo: Memo = {
@@ -74,6 +77,7 @@ export async function GET() {
           transcript,
           summary,
           todos,
+          title: title.trim() || undefined,
           path: path.join(TODOS_DIR, `${baseFilename}.md`), // Keep the TODOs path for editing
           createdAt: parseTimestampFromFilename(baseFilename),
           audioUrl: `/api/audio/${baseFilename}.m4a`

--- a/src/app/plugins/[pluginId]/page.tsx
+++ b/src/app/plugins/[pluginId]/page.tsx
@@ -122,6 +122,7 @@ async function getPluginContent(pluginId: string): Promise<{ files: PluginFile[]
 
   try {
     const entries = await fs.readdir(pluginDir, { withFileTypes: true });
+    
     const filePromises = entries
       .filter(entry => entry.isFile())
       .map(async entry => {

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -481,7 +481,13 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
               className="block hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
             >
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                {formatTimeAgo(memo.createdAt)}
+                {memo.title ? (
+                  <>
+                    {formatTimeAgo(memo.createdAt)} - {memo.title}
+                  </>
+                ) : (
+                  formatTimeAgo(memo.createdAt)
+                )}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {formatShortDate(memo.createdAt)}

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -481,16 +481,15 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
               className="block hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
             >
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                {memo.title ? (
-                  <>
-                    {formatTimeAgo(memo.createdAt)} - {memo.title}
-                  </>
-                ) : (
-                  formatTimeAgo(memo.createdAt)
-                )}
+                {memo.title || formatTimeAgo(memo.createdAt)}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                {formatShortDate(memo.createdAt)}
+                {memo.title && (
+                  <>
+                    {formatTimeAgo(memo.createdAt)} · {formatShortDate(memo.createdAt)}
+                  </>
+                )}
+                {!memo.title && formatShortDate(memo.createdAt)}
                 {duration && ` · ${formatDuration(duration)}`}
                 {memo.transcript && ` · ${countWords(memo.transcript)} words`}
               </p>

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -193,7 +193,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
     if (diffInDays === 0) return 'Today';
     if (diffInDays === 1) return 'Yesterday';
     if (diffInDays < 7) return `${diffInDays} days ago`;
-    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+    if (diffInDays < 30) {
+      const weeks = Math.floor(diffInDays / 7);
+      return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
+    }
     return new Intl.DateTimeFormat('en-US', {
       month: 'short',
       day: 'numeric'

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -44,8 +44,8 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
       }
     });
 
-    // Sort by creation date (newest first)
-    allTitles.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    // Sort by full timestamp (newest first) - use filename for proper chronological ordering
+    allTitles.sort((a, b) => b.filename.localeCompare(a.filename));
     
     setTitles(allTitles);
     setDisplayedTitles(allTitles.slice(0, ITEMS_PER_PAGE));

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -57,6 +57,10 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
     setDisplayedTitles([...displayedTitles, ...nextTitles]);
   };
 
+  const handleLoadAll = () => {
+    setDisplayedTitles(titles);
+  };
+
   const hasMore = displayedTitles.length < titles.length;
 
   const formatDate = (dateStr: string) => {
@@ -127,12 +131,18 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
       </div>
       
       {hasMore && (
-        <div className="flex justify-center pt-6">
+        <div className="flex justify-center gap-3 pt-6">
           <button
             onClick={handleLoadMore}
             className="px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors"
           >
             Load more
+          </button>
+          <button
+            onClick={handleLoadAll}
+            className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 bg-gray-50 dark:bg-gray-900/20 rounded-md hover:bg-gray-100 dark:hover:bg-gray-900/30 transition-colors"
+          >
+            Load all
           </button>
         </div>
       )}

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface TitleEntry {
+  id: string;
+  title: string;
+  filename: string;
+  createdAt: string;
+}
+
+interface TitlesPluginProps {
+  files: {
+    name: string;
+    path: string;
+    content?: string;
+  }[];
+}
+
+const ITEMS_PER_PAGE = 15;
+
+const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
+  const [titles, setTitles] = useState<TitleEntry[]>([]);
+  const [displayedTitles, setDisplayedTitles] = useState<TitleEntry[]>([]);
+
+  useEffect(() => {
+    // Parse titles from files
+    const allTitles: TitleEntry[] = [];
+    
+    files.forEach(file => {
+      const content = file.content || '';
+      const title = content.trim();
+      
+      if (title) {
+        const titleEntry: TitleEntry = {
+          id: file.name,
+          title: title,
+          filename: file.name,
+          createdAt: file.name.split('_')[0] // Format: YYYYMMDD
+        };
+        
+        allTitles.push(titleEntry);
+      }
+    });
+
+    // Sort by creation date (newest first)
+    allTitles.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    
+    setTitles(allTitles);
+    setDisplayedTitles(allTitles.slice(0, ITEMS_PER_PAGE));
+  }, [files]);
+
+  const handleLoadMore = () => {
+    const currentLength = displayedTitles.length;
+    const nextTitles = titles.slice(currentLength, currentLength + ITEMS_PER_PAGE);
+    setDisplayedTitles([...displayedTitles, ...nextTitles]);
+  };
+
+  const hasMore = displayedTitles.length < titles.length;
+
+  const formatDate = (dateStr: string) => {
+    if (dateStr.length === 8) {
+      const year = dateStr.substring(0, 4);
+      const month = dateStr.substring(4, 6);
+      const day = dateStr.substring(6, 8);
+      return new Date(`${year}-${month}-${day}`).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      });
+    }
+    return dateStr;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Titles
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Browse your voice memo titles
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {displayedTitles.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-500 dark:text-gray-400">No titles found</p>
+          </div>
+        ) : (
+          displayedTitles.map((titleEntry) => (
+            <Link
+              key={titleEntry.id}
+              href={`/memos/${titleEntry.filename}`}
+              className="block p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-white truncate">
+                    {titleEntry.title}
+                  </h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                    {formatDate(titleEntry.createdAt)}
+                  </p>
+                </div>
+                <div className="ml-4 flex-shrink-0">
+                  <svg
+                    className="w-5 h-5 text-gray-400 dark:text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </Link>
+          ))
+        )}
+      </div>
+      
+      {hasMore && (
+        <div className="flex justify-center pt-6">
+          <button
+            onClick={handleLoadMore}
+            className="px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors"
+          >
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TitlesPlugin;

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -93,7 +93,7 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
           displayedTitles.map((titleEntry) => (
             <Link
               key={titleEntry.id}
-              href={`/memos/${titleEntry.filename}`}
+              href={`/memos/${titleEntry.filename.replace('.txt', '')}`}
               className="block p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
             >
               <div className="flex items-center justify-between">

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -29,6 +29,11 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
     const allTitles: TitleEntry[] = [];
     
     files.forEach(file => {
+      // Skip hidden files (files that start with a dot)
+      if (file.name.startsWith('.')) {
+        return;
+      }
+      
       const content = file.content || '';
       const title = content.trim();
       

--- a/src/types/VoiceMemo.ts
+++ b/src/types/VoiceMemo.ts
@@ -7,6 +7,7 @@ export interface VoiceMemo {
   todos?: string;
   prompts?: string;
   drafts?: string;
+  title?: string;
   audioUrl: string;
   createdAt: Date;
 }


### PR DESCRIPTION
This PR adds a new titles plugin that displays voice memo titles in a clean, minimalistic interface. The plugin reads title files from the VoiceMemos/titles directory and presents them sorted by recording time with newest first. Additionally, memo cards now display titles when available, showing just the title in the main heading and moving relative time to the subtitle line for better visual hierarchy.

• Added titles plugin with load more/load all functionality
• Integrated title display in memo cards with improved layout
• Fixed relative time pluralization and individual memo page title loading