### PR TITLE
Add title refresh functionality to titles plugin and memo cards

### DIFF
--- a/src/app/api/memos/[filename]/route.ts
+++ b/src/app/api/memos/[filename]/route.ts
@@ -30,15 +30,17 @@ export async function GET(
     const TRANSCRIPTS_DIR = path.join(VOICE_MEMOS_DIR, 'transcripts');
     const SUMMARIES_DIR = path.join(VOICE_MEMOS_DIR, 'summaries');
     const TODOS_DIR = path.join(VOICE_MEMOS_DIR, 'TODOs');
+    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
 
     const { filename } = await params;
     const baseFilename = filename;
     
     // Get content from each plugin directory
-    const [transcript, summary, todos] = await Promise.all([
+    const [transcript, summary, todos, title] = await Promise.all([
       readFileIfExists(path.join(TRANSCRIPTS_DIR, `${baseFilename}.txt`)),
       readFileIfExists(path.join(SUMMARIES_DIR, `${baseFilename}.txt`)),
-      readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`))
+      readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`)),
+      readFileIfExists(path.join(TITLES_DIR, `${baseFilename}.txt`))
     ]);
 
     const memo = {
@@ -46,6 +48,7 @@ export async function GET(
       transcript,
       summary,
       todos,
+      title: title?.trim() || undefined,
       path: path.join(TODOS_DIR, `${baseFilename}.md`),
       createdAt: parseTimestampFromFilename(baseFilename),
       audioUrl: `/api/audio/${baseFilename}.m4a`

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -7,6 +7,7 @@ interface Memo {
   transcript?: string;
   summary?: string;
   todos?: string;
+  title?: string;
   createdAt: string;
   path: string;
   audioUrl: string;
@@ -45,6 +46,7 @@ export async function GET() {
     const TRANSCRIPTS_DIR = path.join(VOICE_MEMOS_DIR, 'transcripts');
     const SUMMARIES_DIR = path.join(VOICE_MEMOS_DIR, 'summaries');
     const TODOS_DIR = path.join(VOICE_MEMOS_DIR, 'TODOs');
+    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
 
     // Ensure default directories exist
     await Promise.all([
@@ -63,10 +65,11 @@ export async function GET() {
         const baseFilename = path.basename(audioFile, '.m4a');
         
         // Get content from each plugin directory
-        const [transcript, summary, todos] = await Promise.all([
+        const [transcript, summary, todos, title] = await Promise.all([
           readFileIfExists(path.join(TRANSCRIPTS_DIR, `${baseFilename}.txt`)),
           readFileIfExists(path.join(SUMMARIES_DIR, `${baseFilename}.txt`)),
-          readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`))
+          readFileIfExists(path.join(TODOS_DIR, `${baseFilename}.md`)),
+          readFileIfExists(path.join(TITLES_DIR, `${baseFilename}.txt`))
         ]);
 
         const memo: Memo = {
@@ -74,6 +77,7 @@ export async function GET() {
           transcript,
           summary,
           todos,
+          title: title.trim() || undefined,
           path: path.join(TODOS_DIR, `${baseFilename}.md`), // Keep the TODOs path for editing
           createdAt: parseTimestampFromFilename(baseFilename),
           audioUrl: `/api/audio/${baseFilename}.m4a`

--- a/src/app/plugins/[pluginId]/page.tsx
+++ b/src/app/plugins/[pluginId]/page.tsx
@@ -122,6 +122,7 @@ async function getPluginContent(pluginId: string): Promise<{ files: PluginFile[]
 
   try {
     const entries = await fs.readdir(pluginDir, { withFileTypes: true });
+    
     const filePromises = entries
       .filter(entry => entry.isFile())
       .map(async entry => {

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -481,7 +481,13 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
               className="block hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
             >
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                {formatTimeAgo(memo.createdAt)}
+                {memo.title ? (
+                  <>
+                    {formatTimeAgo(memo.createdAt)} - {memo.title}
+                  </>
+                ) : (
+                  formatTimeAgo(memo.createdAt)
+                )}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {formatShortDate(memo.createdAt)}

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -481,16 +481,15 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
               className="block hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
             >
               <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                {memo.title ? (
-                  <>
-                    {formatTimeAgo(memo.createdAt)} - {memo.title}
-                  </>
-                ) : (
-                  formatTimeAgo(memo.createdAt)
-                )}
+                {memo.title || formatTimeAgo(memo.createdAt)}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                {formatShortDate(memo.createdAt)}
+                {memo.title && (
+                  <>
+                    {formatTimeAgo(memo.createdAt)} · {formatShortDate(memo.createdAt)}
+                  </>
+                )}
+                {!memo.title && formatShortDate(memo.createdAt)}
                 {duration && ` · ${formatDuration(duration)}`}
                 {memo.transcript && ` · ${countWords(memo.transcript)} words`}
               </p>

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -193,7 +193,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
     if (diffInDays === 0) return 'Today';
     if (diffInDays === 1) return 'Yesterday';
     if (diffInDays < 7) return `${diffInDays} days ago`;
-    if (diffInDays < 30) return `${Math.floor(diffInDays / 7)} weeks ago`;
+    if (diffInDays < 30) {
+      const weeks = Math.floor(diffInDays / 7);
+      return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
+    }
     return new Intl.DateTimeFormat('en-US', {
       month: 'short',
       day: 'numeric'

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -29,6 +29,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSummaryRefreshing, setIsSummaryRefreshing] = useState(false);
   const [isTodosRefreshing, setIsTodosRefreshing] = useState(false);
+  const [isTitleRefreshing, setIsTitleRefreshing] = useState(false);
   const [countdown, setCountdown] = useState<{ [key: string]: number }>({});
   const [isDeleting, setIsDeleting] = useState<{ [key: string]: boolean }>({});
   const deleteIntervals = useRef<{ [key: string]: NodeJS.Timeout | null }>({});
@@ -369,6 +370,9 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
       case 'todos':
         setIsTodosRefreshing(true);
         break;
+      case 'titles':
+        setIsTitleRefreshing(true);
+        break;
     }
     
     try {
@@ -398,6 +402,9 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
         case 'todos':
           memo.todos = undefined;
           break;
+        case 'titles':
+          memo.title = undefined;
+          break;
       }
       
       console.log(`${plugin} files deleted successfully`);
@@ -414,6 +421,9 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
           break;
         case 'todos':
           setIsTodosRefreshing(false);
+          break;
+        case 'titles':
+          setIsTitleRefreshing(false);
           break;
       }
       // Reset countdown and deleting states
@@ -483,9 +493,39 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo }) => {
               href={`/memos/${memo.filename}`}
               className="block hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
             >
-              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                {memo.title || formatTimeAgo(memo.createdAt)}
-              </h3>
+              <div className="flex items-center gap-2">
+                <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                  {memo.title || formatTimeAgo(memo.createdAt)}
+                </h3>
+                {memo.title && (
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (isDeleting['titles']) {
+                        cancelDelete('titles');
+                      } else {
+                        startDeleteCountdown('titles');
+                      }
+                    }}
+                    className={`p-1 transition-colors flex items-center gap-1 ${
+                      isDeleting['titles'] 
+                        ? 'text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300' 
+                        : 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
+                    }`}
+                    title="Refresh title (delete and regenerate)"
+                  >
+                    {isDeleting['titles'] ? (
+                      <>
+                        <TrashIcon className="w-3 h-3" />
+                        <span className="text-xs">{countdown['titles']}s</span>
+                      </>
+                    ) : (
+                      <ArrowPathIcon className="w-3 h-3" />
+                    )}
+                  </button>
+                )}
+              </div>
               <p className="text-sm text-gray-500 dark:text-gray-400">
                 {memo.title && (
                   <>

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -44,8 +44,8 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
       }
     });
 
-    // Sort by creation date (newest first)
-    allTitles.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    // Sort by full timestamp (newest first) - use filename for proper chronological ordering
+    allTitles.sort((a, b) => b.filename.localeCompare(a.filename));
     
     setTitles(allTitles);
     setDisplayedTitles(allTitles.slice(0, ITEMS_PER_PAGE));

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -57,6 +57,10 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
     setDisplayedTitles([...displayedTitles, ...nextTitles]);
   };
 
+  const handleLoadAll = () => {
+    setDisplayedTitles(titles);
+  };
+
   const hasMore = displayedTitles.length < titles.length;
 
   const formatDate = (dateStr: string) => {
@@ -127,12 +131,18 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
       </div>
       
       {hasMore && (
-        <div className="flex justify-center pt-6">
+        <div className="flex justify-center gap-3 pt-6">
           <button
             onClick={handleLoadMore}
             className="px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors"
           >
             Load more
+          </button>
+          <button
+            onClick={handleLoadAll}
+            className="px-4 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 bg-gray-50 dark:bg-gray-900/20 rounded-md hover:bg-gray-100 dark:hover:bg-gray-900/30 transition-colors"
+          >
+            Load all
           </button>
         </div>
       )}

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
+import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/solid';
 
 interface TitleEntry {
   id: string;
@@ -23,6 +24,9 @@ const ITEMS_PER_PAGE = 15;
 const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
   const [titles, setTitles] = useState<TitleEntry[]>([]);
   const [displayedTitles, setDisplayedTitles] = useState<TitleEntry[]>([]);
+  const [countdown, setCountdown] = useState<{ [key: string]: number }>({});
+  const [isDeleting, setIsDeleting] = useState<{ [key: string]: boolean }>({});
+  const deleteIntervals = useRef<{ [key: string]: NodeJS.Timeout | null }>({});
 
   useEffect(() => {
     // Parse titles from files
@@ -65,6 +69,85 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
   const handleLoadAll = () => {
     setDisplayedTitles(titles);
   };
+
+  const handleDeleteTitle = async (filename: string): Promise<void> => {
+    try {
+      const response = await fetch('/api/plugins/delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          filename: filename,
+          plugin: 'titles'
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to delete title file');
+      }
+
+      // Remove the title from the local state
+      setTitles(prev => prev.filter(title => title.filename !== filename));
+      setDisplayedTitles(prev => prev.filter(title => title.filename !== filename));
+      
+      console.log('Title file deleted successfully');
+    } catch (error) {
+      console.error('Error deleting title file:', error);
+    } finally {
+      // Reset countdown and deleting states
+      setCountdown(prev => ({ ...prev, [filename]: 0 }));
+      setIsDeleting(prev => ({ ...prev, [filename]: false }));
+    }
+  };
+
+  const startDeleteCountdown = (filename: string): void => {
+    // Clear any existing interval for this file
+    if (deleteIntervals.current[filename]) {
+      clearInterval(deleteIntervals.current[filename]);
+    }
+
+    setCountdown(prev => ({ ...prev, [filename]: 5 }));
+    setIsDeleting(prev => ({ ...prev, [filename]: true }));
+    
+    const interval = setInterval(() => {
+      setCountdown(prev => {
+        const newCount = prev[filename] - 1;
+        if (newCount <= 0) {
+          clearInterval(interval);
+          handleDeleteTitle(filename);
+          return { ...prev, [filename]: 0 };
+        }
+        return { ...prev, [filename]: newCount };
+      });
+    }, 1000);
+
+    // Store the interval ID
+    deleteIntervals.current[filename] = interval;
+  };
+
+  const cancelDelete = (filename: string): void => {
+    // Clear the interval
+    if (deleteIntervals.current[filename]) {
+      clearInterval(deleteIntervals.current[filename]);
+      deleteIntervals.current[filename] = null;
+    }
+    
+    setCountdown(prev => ({ ...prev, [filename]: 0 }));
+    setIsDeleting(prev => ({ ...prev, [filename]: false }));
+  };
+
+  // Clean up intervals when component unmounts
+  React.useEffect(() => {
+    const intervals = deleteIntervals.current;
+    return () => {
+      Object.values(intervals).forEach(interval => {
+        if (interval) {
+          clearInterval(interval);
+        }
+      });
+    };
+  }, []);
 
   const hasMore = displayedTitles.length < titles.length;
 
@@ -114,7 +197,33 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
                     {formatDate(titleEntry.createdAt)}
                   </p>
                 </div>
-                <div className="ml-4 flex-shrink-0">
+                <div className="ml-4 flex-shrink-0 flex items-center gap-2">
+                  <button
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      if (isDeleting[titleEntry.filename]) {
+                        cancelDelete(titleEntry.filename);
+                      } else {
+                        startDeleteCountdown(titleEntry.filename);
+                      }
+                    }}
+                    className={`p-1 transition-colors flex items-center gap-1 ${
+                      isDeleting[titleEntry.filename] 
+                        ? 'text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300' 
+                        : 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300'
+                    }`}
+                    title="Refresh title (delete and regenerate)"
+                  >
+                    {isDeleting[titleEntry.filename] ? (
+                      <>
+                        <TrashIcon className="w-3 h-3" />
+                        <span className="text-xs">{countdown[titleEntry.filename]}s</span>
+                      </>
+                    ) : (
+                      <ArrowPathIcon className="w-3 h-3" />
+                    )}
+                  </button>
                   <svg
                     className="w-5 h-5 text-gray-400 dark:text-gray-500"
                     fill="none"

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+
+interface TitleEntry {
+  id: string;
+  title: string;
+  filename: string;
+  createdAt: string;
+}
+
+interface TitlesPluginProps {
+  files: {
+    name: string;
+    path: string;
+    content?: string;
+  }[];
+}
+
+const ITEMS_PER_PAGE = 15;
+
+const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
+  const [titles, setTitles] = useState<TitleEntry[]>([]);
+  const [displayedTitles, setDisplayedTitles] = useState<TitleEntry[]>([]);
+
+  useEffect(() => {
+    // Parse titles from files
+    const allTitles: TitleEntry[] = [];
+    
+    files.forEach(file => {
+      const content = file.content || '';
+      const title = content.trim();
+      
+      if (title) {
+        const titleEntry: TitleEntry = {
+          id: file.name,
+          title: title,
+          filename: file.name,
+          createdAt: file.name.split('_')[0] // Format: YYYYMMDD
+        };
+        
+        allTitles.push(titleEntry);
+      }
+    });
+
+    // Sort by creation date (newest first)
+    allTitles.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    
+    setTitles(allTitles);
+    setDisplayedTitles(allTitles.slice(0, ITEMS_PER_PAGE));
+  }, [files]);
+
+  const handleLoadMore = () => {
+    const currentLength = displayedTitles.length;
+    const nextTitles = titles.slice(currentLength, currentLength + ITEMS_PER_PAGE);
+    setDisplayedTitles([...displayedTitles, ...nextTitles]);
+  };
+
+  const hasMore = displayedTitles.length < titles.length;
+
+  const formatDate = (dateStr: string) => {
+    if (dateStr.length === 8) {
+      const year = dateStr.substring(0, 4);
+      const month = dateStr.substring(4, 6);
+      const day = dateStr.substring(6, 8);
+      return new Date(`${year}-${month}-${day}`).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+      });
+    }
+    return dateStr;
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Titles
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          Browse your voice memo titles
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {displayedTitles.length === 0 ? (
+          <div className="text-center py-12">
+            <p className="text-gray-500 dark:text-gray-400">No titles found</p>
+          </div>
+        ) : (
+          displayedTitles.map((titleEntry) => (
+            <Link
+              key={titleEntry.id}
+              href={`/memos/${titleEntry.filename}`}
+              className="block p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-white truncate">
+                    {titleEntry.title}
+                  </h3>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                    {formatDate(titleEntry.createdAt)}
+                  </p>
+                </div>
+                <div className="ml-4 flex-shrink-0">
+                  <svg
+                    className="w-5 h-5 text-gray-400 dark:text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </div>
+              </div>
+            </Link>
+          ))
+        )}
+      </div>
+      
+      {hasMore && (
+        <div className="flex justify-center pt-6">
+          <button
+            onClick={handleLoadMore}
+            className="px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md hover:bg-indigo-100 dark:hover:bg-indigo-900/30 transition-colors"
+          >
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TitlesPlugin;

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -93,7 +93,7 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
           displayedTitles.map((titleEntry) => (
             <Link
               key={titleEntry.id}
-              href={`/memos/${titleEntry.filename}`}
+              href={`/memos/${titleEntry.filename.replace('.txt', '')}`}
               className="block p-4 bg-white dark:bg-gray-800 rounded-lg shadow-sm hover:shadow-md transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
             >
               <div className="flex items-center justify-between">

--- a/src/plugins/titles.tsx
+++ b/src/plugins/titles.tsx
@@ -29,6 +29,11 @@ const TitlesPlugin: React.FC<TitlesPluginProps> = ({ files }) => {
     const allTitles: TitleEntry[] = [];
     
     files.forEach(file => {
+      // Skip hidden files (files that start with a dot)
+      if (file.name.startsWith('.')) {
+        return;
+      }
+      
       const content = file.content || '';
       const title = content.trim();
       

--- a/src/types/VoiceMemo.ts
+++ b/src/types/VoiceMemo.ts
@@ -7,6 +7,7 @@ export interface VoiceMemo {
   todos?: string;
   prompts?: string;
   drafts?: string;
+  title?: string;
   audioUrl: string;
   createdAt: Date;
 }


### PR DESCRIPTION
This PR adds refresh functionality to both the titles plugin and individual memo cards, allowing users to delete and regenerate title files. The implementation reuses existing delete patterns and API endpoints for consistency, providing a 5-second countdown with cancellation option before deletion. The refresh buttons are positioned contextually - next to each title in the titles plugin and adjacent to the title text in memo cards.

• Added refresh button to titles plugin with countdown and cancellation
• Added title refresh button to memo cards when title exists
• Reused existing delete API and patterns for consistency