### PR TITLE
Fix TODO refresh functionality

### DIFF
--- a/src/app/api/plugins/delete/route.ts
+++ b/src/app/api/plugins/delete/route.ts
@@ -51,6 +51,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       })
     );
 
+    // Special handling for TODOs: also delete the corresponding action_item file
+    if (plugin === 'TODOs') {
+      const actionItemsDir = path.join(VOICE_MEMOS_DIR, 'action_items');
+      const actionItemPath = path.join(actionItemsDir, `${baseFilename}.txt`);
+      
+      if (existsSync(actionItemPath)) {
+        await fs.unlink(actionItemPath);
+        console.log(`Also deleted action_item file: ${actionItemPath}`);
+      }
+    }
+
     return NextResponse.json({ 
       success: true, 
       deletedFiles: filesToDelete,


### PR DESCRIPTION
Fixes the TODO refresh (delete and regenerate) functionality by ensuring both TODO files and their corresponding action_item source files are deleted when refreshing. Previously, only the TODO markdown files were deleted while the action_item files remained, preventing proper regeneration since TODOs are generated from action_items.

• Enhanced  API with special handling for TODOs
• Action_item files are now deleted alongside TODO files during refresh
• Maintains backward compatibility for other plugin types