### PR TITLE
refactor: remove duration-related functionality from voice memos

### DIFF
--- a/src/components/MemoList.tsx
+++ b/src/components/MemoList.tsx
@@ -19,41 +19,6 @@ export function MemoList({ initialMemos }: MemoListProps) {
     setMemos(initialMemos);
   }, [initialMemos, setMemos]);
 
-  // Load audio durations on client and enrich memos
-  useEffect(() => {
-    let isCancelled = false;
-
-    async function loadDurations(memos: VoiceMemo[]): Promise<VoiceMemo[]> {
-      const updated = await Promise.all(
-        memos.map(async (memo) => {
-          if (memo.durationSec != null) return memo;
-          try {
-            const audio = document.createElement('audio');
-            audio.src = memo.audioUrl;
-            await new Promise<void>((resolve, reject) => {
-              audio.addEventListener('loadedmetadata', () => resolve());
-              audio.addEventListener('error', () => reject(new Error('audio load error')));
-            });
-            const durationSec = isFinite(audio.duration) ? Math.round(audio.duration) : undefined;
-            return { ...memo, durationSec } as VoiceMemo;
-          } catch {
-            return memo;
-          }
-        })
-      );
-      return updated;
-    }
-
-    loadDurations(initialMemos).then((withDurations) => {
-      if (isCancelled) return;
-      setMemos(withDurations);
-    });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [initialMemos, setMemos]);
-
   useEffect(() => {
     setDisplayedMemos(filteredMemos.slice(0, ITEMS_PER_PAGE));
   }, [filteredMemos]);

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -40,24 +40,6 @@ const containsAllPhrases = (text: string, phrases: string[]): boolean => {
   return phrases.every(phrase => lowerText.includes(phrase.toLowerCase()));
 };
 
-// Parse duration query like "<1min", ">=30s", ">1h" into an operator and seconds
-const parseDurationQuery = (query: string): { op: '<' | '>' | '<=' | '>='; seconds: number } | null => {
-  const trimmed = query.trim().toLowerCase();
-  const match = trimmed.match(/^([<>]=?)\s*(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours)$/);
-  if (!match) return null;
-  const op = match[1] as '<' | '>' | '<=' | '>=';
-  const value = parseFloat(match[2]);
-  const unit = match[3];
-
-  let multiplier = 1; // seconds
-  if (unit.startsWith('s')) multiplier = 1;
-  else if (unit.startsWith('m')) multiplier = 60;
-  else if (unit.startsWith('h')) multiplier = 3600;
-
-  const seconds = Math.round(value * multiplier);
-  return { op, seconds };
-};
-
 export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [memos, setMemos] = useState<VoiceMemo[]>([]);
@@ -82,22 +64,8 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({ children }) => {
     // Apply text search
     if (searchTerm) {
       const term = searchTerm.toLowerCase();
-
-      // Duration query: e.g., "<1min", ">5m", ">=1h"
-      const durationQuery = parseDurationQuery(term);
-      if (durationQuery) {
-        const { op, seconds } = durationQuery;
-        filtered = filtered.filter(memo => {
-          const d = memo.durationSec;
-          if (typeof d !== 'number') return false;
-          switch (op) {
-            case '<': return d < seconds;
-            case '<=': return d <= seconds;
-            case '>': return d > seconds;
-            case '>=': return d >= seconds;
-          }
-        });
-      } else if (term.startsWith('#')) {
+      
+      if (term.startsWith('#')) {
         // Handle hashtag search - extract hashtags without the # symbol
         const searchTag = term.slice(1);
         filtered = filtered.filter(memo => {

--- a/src/types/VoiceMemo.ts
+++ b/src/types/VoiceMemo.ts
@@ -23,5 +23,4 @@ export interface VoiceMemo {
   yolopost?: {
     id: string;
   };
-  durationSec?: number;
 }


### PR DESCRIPTION
Add phrase search, e.g. `"search for this" "and that"` will only show voice memos that contain BOTH `search for this` as well as `and that`.