### PR TITLE
feat: implement dynamic page titles based on content

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,7 +9,10 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'Vibeline',
+  title: {
+    default: 'Vibeline',
+    template: '%s | Vibeline'
+  },
   description: 'Call 555-vibe to vibe it into existence 🤙',
 };
 

--- a/src/app/memos/[filename]/page.tsx
+++ b/src/app/memos/[filename]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import { VoiceMemoCard } from '@/components/VoiceMemoCard';
 import { SearchProvider } from '@/contexts/SearchContext';
+import type { Metadata } from 'next';
 
 async function getMemo(filename: string) {
   const port = process.env.PORT || '555';
@@ -18,6 +19,22 @@ async function getMemo(filename: string) {
   }
 
   return response.json();
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ filename: string }> }): Promise<Metadata> {
+  const { filename } = await params;
+  const memo = await getMemo(filename);
+
+  if (!memo) {
+    return {
+      title: 'Memo Not Found',
+    };
+  }
+
+  const title = memo.title || filename;
+  return {
+    title: title,
+  };
 }
 
 export default async function MemoPage({ params }: { params: Promise<{ filename: string }> }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,14 @@ import { SearchBar } from '@/components/SearchBar';
 import { MemoList } from '@/components/MemoList';
 import { FilterButtons } from '@/components/FilterButtons';
 import Link from 'next/link';
+import type { Metadata } from 'next';
 
 export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Voice Memos',
+  description: 'Call 555-vibe to vibe it into existence 🤙',
+};
 
 async function getData() {
   const port = process.env.PORT || '555';

--- a/src/app/plugins/[pluginId]/page.tsx
+++ b/src/app/plugins/[pluginId]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { existsSync } from 'fs';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
+import type { Metadata } from 'next';
 
 const VOICE_MEMOS_DIR = path.join(process.cwd(), 'VoiceMemos');
 const PLUGINS_DIR = path.join(process.cwd(), 'src', 'plugins');
@@ -196,6 +197,17 @@ function DefaultPluginUI({ files, pluginId }: { files: PluginFile[]; pluginId: s
       )}
     </div>
   );
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ pluginId: string }> }): Promise<Metadata> {
+  const { pluginId } = await params;
+  
+  // Format the plugin ID for display (capitalize and replace underscores with spaces)
+  const formattedTitle = pluginId.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  
+  return {
+    title: formattedTitle,
+  };
 }
 
 export default async function PluginPage({ params }: { params: Promise<{ pluginId: string }> }) {


### PR DESCRIPTION
This PR adds dynamic page titles that update based on the current content being viewed. The root layout now uses a title template format, and individual pages generate appropriate metadata. Memo pages display the memo title or filename, plugin pages show formatted plugin names, and the home page shows 'Voice Memos'. This improves browser tab identification and overall user experience.

- Add  functions to memo and plugin pages
- Update root layout to use title template format
- Set appropriate titles for home page and error states