### PR TITLE
Fix TODO refresh to delete action_items files

### DIFF
--- a/src/app/api/memos/[filename]/refresh/route.ts
+++ b/src/app/api/memos/[filename]/refresh/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
+import { deleteActionItemFile } from '@/utils/deleteUtils';
 
 export async function POST(
   request: NextRequest,
@@ -42,16 +43,9 @@ export async function POST(
     // Check if any of the deleted files were from the TODOs directory
     const deletedTodosFiles = deletedFiles.filter(file => file.startsWith('TODOs/'));
     if (deletedTodosFiles.length > 0) {
-      const actionItemsDir = path.join(VOICE_MEMOS_DIR, 'action_items');
-      const actionItemPath = path.join(actionItemsDir, `${baseFilename}.txt`);
-      
-      try {
-        await fs.unlink(actionItemPath);
-        deletedFiles.push(path.relative(VOICE_MEMOS_DIR, actionItemPath));
-        console.log(`Also deleted action_item file: ${actionItemPath}`);
-      } catch (error) {
-        // If the action_item file doesn't exist, that's fine - just log it
-        console.log(`Action item file not found: ${actionItemPath}`);
+      const deletedActionItemPath = await deleteActionItemFile(VOICE_MEMOS_DIR, baseFilename);
+      if (deletedActionItemPath) {
+        deletedFiles.push(deletedActionItemPath);
       }
     }
     

--- a/src/app/api/memos/[filename]/refresh/route.ts
+++ b/src/app/api/memos/[filename]/refresh/route.ts
@@ -38,6 +38,23 @@ export async function POST(
       }
     }
     
+    // Special handling for TODOs: also delete the corresponding action_item file
+    // Check if any of the deleted files were from the TODOs directory
+    const deletedTodosFiles = deletedFiles.filter(file => file.startsWith('TODOs/'));
+    if (deletedTodosFiles.length > 0) {
+      const actionItemsDir = path.join(VOICE_MEMOS_DIR, 'action_items');
+      const actionItemPath = path.join(actionItemsDir, `${baseFilename}.txt`);
+      
+      try {
+        await fs.unlink(actionItemPath);
+        deletedFiles.push(path.relative(VOICE_MEMOS_DIR, actionItemPath));
+        console.log(`Also deleted action_item file: ${actionItemPath}`);
+      } catch (error) {
+        // If the action_item file doesn't exist, that's fine - just log it
+        console.log(`Action item file not found: ${actionItemPath}`);
+      }
+    }
+    
     return NextResponse.json({
       success: true,
       filename: baseFilename,

--- a/src/app/api/plugins/delete/route.ts
+++ b/src/app/api/plugins/delete/route.ts
@@ -22,13 +22,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Get the base filename without extension
     const baseFilename = path.basename(filename, path.extname(filename));
     
-    // Construct the plugin directory path
-    const pluginDir = path.join(VOICE_MEMOS_DIR, plugin);
+    // Construct the plugin directory path (normalize common alias 'todos' -> 'TODOs')
+    const normalizedPlugin = plugin === 'todos' ? 'TODOs' : plugin;
+    const pluginDir = path.join(VOICE_MEMOS_DIR, normalizedPlugin);
     
     // Check if the plugin directory exists
     if (!existsSync(pluginDir)) {
       return NextResponse.json(
-        { error: `Plugin directory '${plugin}' does not exist` },
+        { error: `Plugin directory '${normalizedPlugin}' does not exist` },
         { status: 404 }
       );
     }
@@ -53,7 +54,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
 
     // Special handling for TODOs: also delete the corresponding action_item file
-    if (plugin === 'TODOs') {
+    if (normalizedPlugin === 'TODOs') {
       await deleteActionItemFile(VOICE_MEMOS_DIR, baseFilename);
     }
 

--- a/src/app/api/plugins/delete/route.ts
+++ b/src/app/api/plugins/delete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { existsSync } from 'fs';
+import { deleteActionItemFile } from '@/utils/deleteUtils';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
@@ -53,13 +54,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     // Special handling for TODOs: also delete the corresponding action_item file
     if (plugin === 'TODOs') {
-      const actionItemsDir = path.join(VOICE_MEMOS_DIR, 'action_items');
-      const actionItemPath = path.join(actionItemsDir, `${baseFilename}.txt`);
-      
-      if (existsSync(actionItemPath)) {
-        await fs.unlink(actionItemPath);
-        console.log(`Also deleted action_item file: ${actionItemPath}`);
-      }
+      await deleteActionItemFile(VOICE_MEMOS_DIR, baseFilename);
     }
 
     return NextResponse.json({ 

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -1003,7 +1003,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
                         if (isDeleting['todos']) {
                           cancelDelete('todos');
                         } else {
-                          startDeleteCountdown('TODOs');
+                          startDeleteCountdown('todos');
                         }
                       }}
                       className={`p-1 transition-colors flex items-center gap-1 ${

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -1003,7 +1003,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
                         if (isDeleting['todos']) {
                           cancelDelete('todos');
                         } else {
-                          startDeleteCountdown('todos');
+                          startDeleteCountdown('TODOs');
                         }
                       }}
                       className={`p-1 transition-colors flex items-center gap-1 ${

--- a/src/utils/deleteUtils.ts
+++ b/src/utils/deleteUtils.ts
@@ -1,0 +1,25 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { existsSync } from 'fs';
+
+/**
+ * Deletes the corresponding action_item file when TODOs are being deleted
+ * @param voiceMemosDir - The VoiceMemos directory path
+ * @param baseFilename - The base filename (without extension)
+ * @returns Promise<string | null> - The deleted file path or null if not found
+ */
+export async function deleteActionItemFile(
+  voiceMemosDir: string, 
+  baseFilename: string
+): Promise<string | null> {
+  const actionItemsDir = path.join(voiceMemosDir, 'action_items');
+  const actionItemPath = path.join(actionItemsDir, `${baseFilename}.txt`);
+  
+  if (existsSync(actionItemPath)) {
+    await fs.unlink(actionItemPath);
+    console.log(`Also deleted action_item file: ${actionItemPath}`);
+    return path.relative(voiceMemosDir, actionItemPath);
+  }
+  
+  return null;
+}


### PR DESCRIPTION
This PR fixes the TODO refresh functionality to properly delete both TODO files and their associated action_items files. The issue was caused by a case sensitivity mismatch between the frontend sending 'todos' and the API expecting 'TODOs', which prevented the action_items deletion logic from executing.

- Extracts action_items deletion logic into shared utility function 
- Normalizes plugin key mapping in API to handle 'todos' -> 'TODOs' directory
- Ensures both refresh and plugin delete routes consistently delete action_items files