### PR TITLE
Add title editing functionality to VoiceMemoCard

### DIFF
--- a/src/app/api/titles/update/route.ts
+++ b/src/app/api/titles/update/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import fs from 'fs/promises';
+import path from 'path';
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    const { filename, title } = await request.json();
+    
+    if (!filename) {
+      return new NextResponse('Filename is required', { status: 400 });
+    }
+    
+    if (!title) {
+      return new NextResponse('Title is required', { status: 400 });
+    }
+    
+    // Resolve the symlink to get the actual path
+    const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
+    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
+    
+    // Construct the title file path
+    const titleFilePath = path.join(TITLES_DIR, `${filename}.txt`);
+    
+    // Security check: ensure the file is within the titles directory
+    const normalizedPath = path.normalize(titleFilePath);
+    if (!normalizedPath.startsWith(TITLES_DIR)) {
+      return new NextResponse('Forbidden', { status: 403 });
+    }
+    
+    // Write the new title to the file
+    await fs.writeFile(titleFilePath, title.trim());
+    
+    return NextResponse.json({ 
+      success: true,
+      filename,
+      title: title.trim()
+    });
+  } catch (error) {
+    console.error('Error updating title:', error);
+    return NextResponse.json(
+      { error: 'Failed to update title' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -359,6 +359,12 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setEditingTitle('');
   };
 
+  const handleTitleBlur = (): void => {
+    // Don't save on blur - only save on explicit Enter key press
+    // Just cancel the editing mode
+    handleTitleCancel();
+  };
+
   const handleTitleKeyDown = (event: React.KeyboardEvent): void => {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -767,7 +773,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
                       value={editingTitle}
                       onChange={(e) => setEditingTitle(e.target.value)}
                       onKeyDown={handleTitleKeyDown}
-                      onBlur={handleTitleSave}
+                      onBlur={handleTitleBlur}
                       className="text-lg font-medium text-gray-900 dark:text-gray-100 bg-transparent border-b border-gray-300 dark:border-gray-600 focus:border-indigo-500 dark:focus:border-indigo-400 focus:outline-none px-1 py-0.5 flex-1"
                       autoFocus
                       disabled={isSavingTitle}


### PR DESCRIPTION
Adds inline title editing capability to voice memo cards with a small edit icon between the title and refresh button. Users can click the pencil icon to transform the title into an editable text field, make changes, and save by pressing Enter. The implementation includes a new API endpoint for updating titles and proper keyboard navigation with Escape to cancel editing.

- New API endpoint `/api/titles/update` for title file updates
- Inline editing with `handleTitleEdit`, `handleTitleSave`, and `handleTitleCancel` functions
- Keyboard shortcuts: Enter to save, Escape to cancel
- Loading state during save operations with optimistic UI updates