### PR TITLE
fix: archive path handling with convention-over-configuration

### DIFF
--- a/src/app/api/archive/[month]/route.ts
+++ b/src/app/api/archive/[month]/route.ts
@@ -129,7 +129,7 @@ export async function GET(
           title: title.trim() || undefined,
           path: path.join(TODOS_DIR, `${baseFilename}.md`),
           createdAt: parseTimestampFromFilename(baseFilename),
-          audioUrl: buildAudioUrl(baseFilename, month),
+          audioUrl: buildAudioUrl(baseFilename),
           archivePath: month,
           blossom: blossomData || undefined,
           yolopost: yolopostData || undefined

--- a/src/app/api/audio/[filename]/route.ts
+++ b/src/app/api/audio/[filename]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { createReadStream, statSync } from 'fs';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function GET(
   request: NextRequest,
@@ -15,9 +15,11 @@ export async function GET(
     const { filename } = await params;
     const decodedFilename = decodeURIComponent(filename);
     
-    // Check for archive query param
-    const archivePath = request.nextUrl.searchParams.get('archive') || undefined;
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    // Extract base filename without extension for location detection
+    const baseFilename = path.basename(decodedFilename, path.extname(decodedFilename));
+    
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     const filePath = path.join(baseDir, decodedFilename);
     
     // Verify file exists and is within the voice memos directory

--- a/src/app/api/memos/[filename]/delete/route.ts
+++ b/src/app/api/memos/[filename]/delete/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function POST(
   request: NextRequest,
@@ -13,10 +13,10 @@ export async function POST(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
-    const { searchParams } = new URL(request.url);
-    const archivePath = searchParams.get('archive') || undefined;
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
+    
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     
     // Use glob to find ALL files matching the pattern (including audio)
     const pattern = path.join(baseDir, '**', `${baseFilename}.*`);

--- a/src/app/api/memos/[filename]/delete/route.ts
+++ b/src/app/api/memos/[filename]/delete/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function POST(
   request: NextRequest,
@@ -12,10 +13,13 @@ export async function POST(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
+    const { searchParams } = new URL(request.url);
+    const archivePath = searchParams.get('archive') || undefined;
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
     
     // Use glob to find ALL files matching the pattern (including audio)
-    const pattern = path.join(VOICE_MEMOS_DIR, '**', `${baseFilename}.*`);
+    const pattern = path.join(baseDir, '**', `${baseFilename}.*`);
     const files = await glob(pattern, { nodir: true });
     
     // Delete ALL matching files (including audio files)
@@ -25,10 +29,10 @@ export async function POST(
     for (const filePath of files) {
       try {
         await fs.unlink(filePath);
-        deletedFiles.push(path.relative(VOICE_MEMOS_DIR, filePath));
+        deletedFiles.push(path.relative(baseDir, filePath));
       } catch (error) {
         console.error(`Error deleting file ${filePath}:`, error);
-        errors.push(path.relative(VOICE_MEMOS_DIR, filePath));
+        errors.push(path.relative(baseDir, filePath));
       }
     }
     

--- a/src/app/api/memos/[filename]/files/all/route.ts
+++ b/src/app/api/memos/[filename]/files/all/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function GET(
   request: Request,
@@ -13,10 +13,10 @@ export async function GET(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
-    const { searchParams } = new URL(request.url);
-    const archivePath = searchParams.get('archive') || undefined;
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
+    
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     
     // Use glob to find ALL files matching the pattern (including audio)
     const pattern = path.join(baseDir, '**', `${baseFilename}.*`);

--- a/src/app/api/memos/[filename]/files/route.ts
+++ b/src/app/api/memos/[filename]/files/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function GET(
   request: Request,
@@ -13,10 +13,10 @@ export async function GET(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
-    const { searchParams } = new URL(request.url);
-    const archivePath = searchParams.get('archive') || undefined;
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
+    
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     
     // Use glob to find all files matching the pattern
     const pattern = path.join(baseDir, '**', `${baseFilename}.*`);

--- a/src/app/api/memos/[filename]/files/route.ts
+++ b/src/app/api/memos/[filename]/files/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function GET(
   request: Request,
@@ -12,10 +13,13 @@ export async function GET(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
+    const { searchParams } = new URL(request.url);
+    const archivePath = searchParams.get('archive') || undefined;
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
     
     // Use glob to find all files matching the pattern
-    const pattern = path.join(VOICE_MEMOS_DIR, '**', `${baseFilename}.*`);
+    const pattern = path.join(baseDir, '**', `${baseFilename}.*`);
     const allMatchingFiles = await glob(pattern, { nodir: true });
     
     // Filter out audio files - we never want to delete the original audio
@@ -28,7 +32,7 @@ export async function GET(
     const filesByCategory: { [category: string]: Array<{ filename: string; fullPath: string }> } = {};
     
     for (const filePath of files) {
-      const relativePath = path.relative(VOICE_MEMOS_DIR, filePath);
+      const relativePath = path.relative(baseDir, filePath);
       const category = path.dirname(relativePath);
       const filename = path.basename(filePath);
       

--- a/src/app/api/memos/[filename]/refresh/route.ts
+++ b/src/app/api/memos/[filename]/refresh/route.ts
@@ -3,7 +3,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { glob } from 'glob';
 import { deleteActionItemFile } from '@/utils/deleteUtils';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function POST(
   request: NextRequest,
@@ -14,10 +14,10 @@ export async function POST(
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
     const { filename } = await params;
-    const { searchParams } = new URL(request.url);
-    const archivePath = searchParams.get('archive') || undefined;
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
     const baseFilename = filename;
+    
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     
     // Use glob to find all files matching the pattern
     const pattern = path.join(baseDir, '**', `${baseFilename}.*`);

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { BlossomData } from '@/types/VoiceMemo';
-import { getBasePath, buildAudioUrl } from '@/lib/archivePaths';
+import { getBasePath, buildAudioUrl, getArchiveMonthFromFilename } from '@/lib/archivePaths';
 
 interface Memo {
   filename: string;
@@ -133,7 +133,7 @@ async function getMemosFromDir(voiceMemosDir: string, archivePath?: string): Pro
         title: title.trim() || undefined,
         path: path.join(TODOS_DIR, `${baseFilename}.md`), // Keep the TODOs path for editing
         createdAt: parseTimestampFromFilename(baseFilename),
-        audioUrl: buildAudioUrl(baseFilename, archivePath),
+        audioUrl: buildAudioUrl(baseFilename),
         archivePath,
         blossom: blossomData || undefined,
         yolopost: yolopostData || undefined

--- a/src/app/api/memos/route.ts
+++ b/src/app/api/memos/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
 import { BlossomData } from '@/types/VoiceMemo';
-import { getBasePath, buildAudioUrl, getArchiveMonthFromFilename } from '@/lib/archivePaths';
+import { getBasePath, buildAudioUrl } from '@/lib/archivePaths';
 
 interface Memo {
   filename: string;

--- a/src/app/api/open-in-finder/route.ts
+++ b/src/app/api/open-in-finder/route.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import path from 'path';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 const execAsync = promisify(exec);
 
@@ -13,13 +13,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
-    const { filename, fileType = 'audio', archivePath } = await request.json();
+    const { filename, fileType = 'audio' } = await request.json();
     if (!filename) {
       return new NextResponse('Filename is required', { status: 400 });
     }
 
-    // Get the base directory (handles archive paths)
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, filename);
 
     let filePath: string;
     let normalizedPath: string;

--- a/src/app/api/plugins/delete/route.ts
+++ b/src/app/api/plugins/delete/route.ts
@@ -23,9 +23,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Get the base filename without extension
     const baseFilename = path.basename(filename, path.extname(filename));
 
-    // Get the base filename without extension
-    const baseFilename = path.basename(filename, path.extname(filename));
-
     // Auto-detect location by convention
     const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, baseFilename);
     

--- a/src/app/api/titles/update/route.ts
+++ b/src/app/api/titles/update/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filename, title, archivePath } = await request.json();
+    const { filename, title } = await request.json();
     
     if (!filename) {
       return new NextResponse('Filename is required', { status: 400 });
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, filename);
     const TITLES_DIR = path.join(baseDir, 'titles');
     
     // Construct the title file path

--- a/src/app/api/titles/update/route.ts
+++ b/src/app/api/titles/update/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filename, title } = await request.json();
+    const { filename, title, archivePath } = await request.json();
     
     if (!filename) {
       return new NextResponse('Filename is required', { status: 400 });
@@ -16,7 +17,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const TITLES_DIR = path.join(VOICE_MEMOS_DIR, 'titles');
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const TITLES_DIR = path.join(baseDir, 'titles');
     
     // Construct the title file path
     const titleFilePath = path.join(TITLES_DIR, `${filename}.txt`);

--- a/src/app/api/todos/toggle/route.ts
+++ b/src/app/api/todos/toggle/route.ts
@@ -1,21 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
 import fs from 'fs/promises';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filePath, lineNumber, completed, archivePath } = await request.json();
+    const { filePath, lineNumber, completed } = await request.json();
     
     if (!filePath) {
       throw new Error('filePath is required');
     }
     
+    // Extract filename from filePath (e.g., "TODOs/20251203_143022.md" -> "20251203_143022")
+    const filename = path.basename(filePath, path.extname(filePath));
+    
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
-    // Get the base directory (handles archive paths)
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    // Auto-detect location by convention
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, filename);
     
     // Read the file using the real path
     const fullPath = path.join(baseDir, filePath);

--- a/src/app/api/todos/toggle/route.ts
+++ b/src/app/api/todos/toggle/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import path from 'path';
 import fs from 'fs/promises';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filePath, lineNumber, completed } = await request.json();
+    const { filePath, lineNumber, completed, archivePath } = await request.json();
     
     if (!filePath) {
       throw new Error('filePath is required');
@@ -13,8 +14,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
     
+    // Get the base directory (handles archive paths)
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    
     // Read the file using the real path
-    const fullPath = path.join(VOICE_MEMOS_DIR, filePath);
+    const fullPath = path.join(baseDir, filePath);
     const content = await fs.readFile(fullPath, 'utf-8');
     const lines = content.split('\n');
 

--- a/src/app/api/todos/update/route.ts
+++ b/src/app/api/todos/update/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filename, content } = await request.json();
+    const { filename, content, archivePath } = await request.json();
     
     if (!filename) {
       return new NextResponse('Filename is required', { status: 400 });
@@ -12,7 +13,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const TODOS_DIR = path.join(VOICE_MEMOS_DIR, 'TODOs');
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const TODOS_DIR = path.join(baseDir, 'TODOs');
     
     // Construct the todo file path
     const todoFilePath = path.join(TODOS_DIR, `${filename}.md`);

--- a/src/app/api/todos/update/route.ts
+++ b/src/app/api/todos/update/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
-    const { filename, content, archivePath } = await request.json();
+    const { filename, content } = await request.json();
     
     if (!filename) {
       return new NextResponse('Filename is required', { status: 400 });
@@ -13,7 +13,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, filename);
     const TODOS_DIR = path.join(baseDir, 'TODOs');
     
     // Construct the todo file path

--- a/src/app/api/transcripts/[filename]/original/route.ts
+++ b/src/app/api/transcripts/[filename]/original/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
-import { getBasePath } from '@/lib/archivePaths';
+import { findMemoBaseDir } from '@/lib/archivePaths';
 
 export async function GET(
   request: Request,
@@ -9,12 +9,10 @@ export async function GET(
 ) {
   try {
     const { filename } = await params;
-    const { searchParams } = new URL(request.url);
-    const archivePath = searchParams.get('archive') || undefined;
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const baseDir = findMemoBaseDir(VOICE_MEMOS_DIR, filename);
     const TRANSCRIPTS_DIR = path.join(baseDir, 'transcripts');
     
     const originalTranscriptPath = path.join(TRANSCRIPTS_DIR, `${filename}.txt.orig`);

--- a/src/app/api/transcripts/[filename]/original/route.ts
+++ b/src/app/api/transcripts/[filename]/original/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import fs from 'fs/promises';
 import path from 'path';
+import { getBasePath } from '@/lib/archivePaths';
 
 export async function GET(
   request: Request,
@@ -8,10 +9,13 @@ export async function GET(
 ) {
   try {
     const { filename } = await params;
+    const { searchParams } = new URL(request.url);
+    const archivePath = searchParams.get('archive') || undefined;
     
     // Resolve the symlink to get the actual path
     const VOICE_MEMOS_DIR = await fs.realpath(path.join(process.cwd(), 'VoiceMemos'));
-    const TRANSCRIPTS_DIR = path.join(VOICE_MEMOS_DIR, 'transcripts');
+    const baseDir = getBasePath(VOICE_MEMOS_DIR, archivePath);
+    const TRANSCRIPTS_DIR = path.join(baseDir, 'transcripts');
     
     const originalTranscriptPath = path.join(TRANSCRIPTS_DIR, `${filename}.txt.orig`);
     

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -400,7 +400,8 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         body: JSON.stringify({ 
           filePath, 
           lineNumber, 
-          completed: newChecked 
+          completed: newChecked,
+          archivePath: memo.archivePath
         }),
       });
   
@@ -411,7 +412,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
       console.error('Failed to toggle todo:', error);
       setOptimisticTodos(null);
     }
-  }, [memo.path, memo.todos, optimisticTodos]);
+  }, [memo.path, memo.todos, memo.archivePath, optimisticTodos]);
 
   // Function to handle checking all todos
   const handleCheckAllTodos = useCallback(async () => {
@@ -453,7 +454,8 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
           body: JSON.stringify({ 
             filePath, 
             lineNumber, 
-            completed: true 
+            completed: true,
+            archivePath: memo.archivePath
           }),
         })
       );
@@ -463,7 +465,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
       console.error('Failed to check all todos:', error);
       setOptimisticTodos(null);
     }
-  }, [memo.path, memo.todos, optimisticTodos]);
+  }, [memo.path, memo.todos, memo.archivePath, optimisticTodos]);
 
   const handleClearTodos = useCallback(async () => {
     // Optimistic UI update - clear todos

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -59,7 +59,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     if (originalTranscript !== null) return; // Already fetched
     
     try {
-      const response = await fetch(`/api/transcripts/${memo.filename}/original`);
+      const url = memo.archivePath 
+        ? `/api/transcripts/${memo.filename}/original?archive=${memo.archivePath}`
+        : `/api/transcripts/${memo.filename}/original`;
+      const response = await fetch(url);
       if (response.ok) {
         const text = await response.text();
         setOriginalTranscript(text);
@@ -333,7 +336,8 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          title: editingTitle.trim()
+          title: editingTitle.trim(),
+          archivePath: memo.archivePath
         }),
       });
 
@@ -479,7 +483,8 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          content: ''
+          content: '',
+          archivePath: memo.archivePath
         }),
       });
 
@@ -558,7 +563,8 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          plugin
+          plugin,
+          archivePath: memo.archivePath
         }),
       });
 
@@ -650,7 +656,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setShowRefreshDialog(true);
     
     try {
-      const response = await fetch(`/api/memos/${memo.filename}/files`);
+      const url = memo.archivePath 
+        ? `/api/memos/${memo.filename}/files?archive=${memo.archivePath}`
+        : `/api/memos/${memo.filename}/files`;
+      const response = await fetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch files');
       }
@@ -670,7 +679,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setRefreshStep('deleting');
     
     try {
-      const response = await fetch(`/api/memos/${memo.filename}/refresh`, {
+      const url = memo.archivePath 
+        ? `/api/memos/${memo.filename}/refresh?archive=${memo.archivePath}`
+        : `/api/memos/${memo.filename}/refresh`;
+      const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -718,7 +730,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setShowDeleteDialog(true);
     
     try {
-      const response = await fetch(`/api/memos/${memo.filename}/files/all`);
+      const url = memo.archivePath 
+        ? `/api/memos/${memo.filename}/files/all?archive=${memo.archivePath}`
+        : `/api/memos/${memo.filename}/files/all`;
+      const response = await fetch(url);
       if (!response.ok) {
         throw new Error('Failed to fetch files');
       }
@@ -738,7 +753,10 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setDeleteStep('deleting');
     
     try {
-      const response = await fetch(`/api/memos/${memo.filename}/delete`, {
+      const url = memo.archivePath 
+        ? `/api/memos/${memo.filename}/delete?archive=${memo.archivePath}`
+        : `/api/memos/${memo.filename}/delete`;
+      const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -59,10 +59,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     if (originalTranscript !== null) return; // Already fetched
     
     try {
-      const url = memo.archivePath 
-        ? `/api/transcripts/${memo.filename}/original?archive=${memo.archivePath}`
-        : `/api/transcripts/${memo.filename}/original`;
-      const response = await fetch(url);
+      const response = await fetch(`/api/transcripts/${memo.filename}/original`);
       if (response.ok) {
         const text = await response.text();
         setOriginalTranscript(text);
@@ -336,8 +333,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          title: editingTitle.trim(),
-          archivePath: memo.archivePath
+          title: editingTitle.trim()
         }),
       });
 
@@ -404,8 +400,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         body: JSON.stringify({ 
           filePath, 
           lineNumber, 
-          completed: newChecked,
-          archivePath: memo.archivePath
+          completed: newChecked
         }),
       });
   
@@ -416,7 +411,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
       console.error('Failed to toggle todo:', error);
       setOptimisticTodos(null);
     }
-  }, [memo.path, memo.todos, memo.archivePath, optimisticTodos]);
+  }, [memo.path, memo.todos, optimisticTodos]);
 
   // Function to handle checking all todos
   const handleCheckAllTodos = useCallback(async () => {
@@ -458,8 +453,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
           body: JSON.stringify({ 
             filePath, 
             lineNumber, 
-            completed: true,
-            archivePath: memo.archivePath
+            completed: true
           }),
         })
       );
@@ -469,7 +463,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
       console.error('Failed to check all todos:', error);
       setOptimisticTodos(null);
     }
-  }, [memo.path, memo.todos, memo.archivePath, optimisticTodos]);
+  }, [memo.path, memo.todos, optimisticTodos]);
 
   const handleClearTodos = useCallback(async () => {
     // Optimistic UI update - clear todos
@@ -483,8 +477,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          content: '',
-          archivePath: memo.archivePath
+          content: ''
         }),
       });
 
@@ -507,7 +500,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ filename: memo.filename, archivePath: memo.archivePath }),
+        body: JSON.stringify({ filename: memo.filename }),
       });
   
       if (!response.ok) {
@@ -525,7 +518,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ filename: memo.filename, fileType: 'transcript', archivePath: memo.archivePath }),
+        body: JSON.stringify({ filename: memo.filename, fileType: 'transcript' }),
       });
   
       if (!response.ok) {
@@ -563,8 +556,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         },
         body: JSON.stringify({ 
           filename: memo.filename,
-          plugin,
-          archivePath: memo.archivePath
+          plugin
         }),
       });
 
@@ -656,10 +648,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setShowRefreshDialog(true);
     
     try {
-      const url = memo.archivePath 
-        ? `/api/memos/${memo.filename}/files?archive=${memo.archivePath}`
-        : `/api/memos/${memo.filename}/files`;
-      const response = await fetch(url);
+      const response = await fetch(`/api/memos/${memo.filename}/files`);
       if (!response.ok) {
         throw new Error('Failed to fetch files');
       }
@@ -679,10 +668,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setRefreshStep('deleting');
     
     try {
-      const url = memo.archivePath 
-        ? `/api/memos/${memo.filename}/refresh?archive=${memo.archivePath}`
-        : `/api/memos/${memo.filename}/refresh`;
-      const response = await fetch(url, {
+      const response = await fetch(`/api/memos/${memo.filename}/refresh`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -730,10 +716,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setShowDeleteDialog(true);
     
     try {
-      const url = memo.archivePath 
-        ? `/api/memos/${memo.filename}/files/all?archive=${memo.archivePath}`
-        : `/api/memos/${memo.filename}/files/all`;
-      const response = await fetch(url);
+      const response = await fetch(`/api/memos/${memo.filename}/files/all`);
       if (!response.ok) {
         throw new Error('Failed to fetch files');
       }
@@ -753,10 +736,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
     setDeleteStep('deleting');
     
     try {
-      const url = memo.archivePath 
-        ? `/api/memos/${memo.filename}/delete?archive=${memo.archivePath}`
-        : `/api/memos/${memo.filename}/delete`;
-      const response = await fetch(url, {
+      const response = await fetch(`/api/memos/${memo.filename}/delete`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/components/VoiceMemoCard.tsx
+++ b/src/components/VoiceMemoCard.tsx
@@ -502,7 +502,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ filename: memo.filename }),
+        body: JSON.stringify({ filename: memo.filename, archivePath: memo.archivePath }),
       });
   
       if (!response.ok) {
@@ -520,7 +520,7 @@ export const VoiceMemoCard: React.FC<VoiceMemoCardProps> = ({ memo, isMemoPage =
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ filename: memo.filename, fileType: 'transcript' }),
+        body: JSON.stringify({ filename: memo.filename, fileType: 'transcript', archivePath: memo.archivePath }),
       });
   
       if (!response.ok) {

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -130,7 +130,7 @@ export const SearchProvider: React.FC<SearchProviderProps> = ({ children, isArch
     }
 
     return filtered;
-  }, [searchTerm, memos, activeFilters]);
+  }, [searchTerm, memos, activeFilters, isArchiveView]);
 
   const value = {
     searchTerm,

--- a/src/lib/archivePaths.ts
+++ b/src/lib/archivePaths.ts
@@ -1,7 +1,48 @@
 import path from 'path';
+import { existsSync } from 'fs';
+
+/**
+ * Derive the archive month from a filename following YYYYMMDD_HHMMSS convention.
+ * @param filename - The memo filename (e.g., "20251203_143022")
+ * @returns Archive folder name like "2025-12" or undefined if invalid format
+ */
+export function getArchiveMonthFromFilename(filename: string): string | undefined {
+  const match = filename.match(/^(\d{4})(\d{2})/);
+  if (!match) return undefined;
+  return `${match[1]}-${match[2]}`;
+}
+
+/**
+ * Auto-locate a memo's base directory by convention.
+ * Checks main directory first, then derives archive location from filename.
+ * @param voiceMemosDir - The root VoiceMemos directory path
+ * @param filename - The memo filename (without extension)
+ * @returns The base directory where the memo files are located
+ */
+export function findMemoBaseDir(voiceMemosDir: string, filename: string): string {
+  // Convention 1: Check main directory first (current/active memos)
+  const mainAudioPath = path.join(voiceMemosDir, `${filename}.m4a`);
+  if (existsSync(mainAudioPath)) {
+    return voiceMemosDir;
+  }
+  
+  // Convention 2: Derive archive location from filename date
+  const archiveMonth = getArchiveMonthFromFilename(filename);
+  if (archiveMonth) {
+    const archiveDir = path.join(voiceMemosDir, 'archive', archiveMonth);
+    const archiveAudioPath = path.join(archiveDir, `${filename}.m4a`);
+    if (existsSync(archiveAudioPath)) {
+      return archiveDir;
+    }
+  }
+  
+  // Fallback to main directory
+  return voiceMemosDir;
+}
 
 /**
  * Get the base path for a memo's files, accounting for archive structure.
+ * @deprecated Use findMemoBaseDir() for convention-based auto-detection
  * @param voiceMemosDir - The root VoiceMemos directory path
  * @param archivePath - Optional archive folder name (e.g., "2025-12")
  * @returns The base path where memo files are located
@@ -13,13 +54,11 @@ export function getBasePath(voiceMemosDir: string, archivePath?: string): string
 }
 
 /**
- * Build the audio URL for a memo, including archive query param if needed.
+ * Build the audio URL for a memo.
  * @param baseFilename - The memo's base filename (without extension)
- * @param archivePath - Optional archive folder name
  * @returns The audio URL path
  */
-export function buildAudioUrl(baseFilename: string, archivePath?: string): string {
-  const base = `/api/audio/${baseFilename}.m4a`;
-  return archivePath ? `${base}?archive=${archivePath}` : base;
+export function buildAudioUrl(baseFilename: string): string {
+  return `/api/audio/${baseFilename}.m4a`;
 }
 


### PR DESCRIPTION
Fix archive path handling across all API routes and refactor to use convention-over-configuration. Previously, archived memos would fail when toggling TODOs, opening in Finder, or performing various operations because the archive path was not being passed correctly. This PR first fixes all affected routes by explicitly passing `archivePath`, then refactors to derive file location automatically from the filename (YYYYMMDD_HHMMSS format).

- Add `findMemoBaseDir()` to auto-locate memos based on filename convention
- Update 12+ API routes to use the new convention-based path resolution
- Remove ~60 explicit `archivePath` references from API calls
